### PR TITLE
Update frontend GitHub Actions workflow to use self-hosted EC2 runner

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -2,22 +2,29 @@ name: Deploy Frontend
 
 on:
   push:
-    branches: [main]
+    branches:
+      - main
     paths:
       - "frontend/**"
 
+concurrency:
+  group: frontend-deploy
+  cancel-in-progress: true
+
 jobs:
   deploy:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, frontend-ec2]
+
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout repository
+        uses: actions/checkout@v4
 
       - name: Set up Node
         uses: actions/setup-node@v4
         with:
           node-version: 20
 
-      - name: Install & Build
+      - name: Install and build frontend
         working-directory: frontend
         run: |
           npm ci
@@ -26,14 +33,12 @@ jobs:
           VITE_API_BASE_URL: ${{ secrets.VITE_API_BASE_URL }}
           VITE_TOTP_SERVICE_URL: ${{ secrets.VITE_TOTP_SERVICE_URL }}
 
-      - name: Deploy to EC2
-        uses: appleboy/ssh-action@v1.0.3
-        with:
-          host: ${{ secrets.FRONTEND_EC2_HOST }}
-          username: ${{ secrets.EC2_USER }}
-          key: ${{ secrets.EC2_SSH_KEY }}
-          script: |
-            cd /var/www/frontend
-            git pull origin main
-            npm ci
-            npm run build
+      - name: Deploy built frontend to Nginx web root
+        run: |
+          test -f frontend/dist/index.html
+          rm -rf /var/www/html/*
+          cp -r frontend/dist/. /var/www/html/
+
+      - name: Verify deployed frontend
+        run: |
+          test -f /var/www/html/index.html

--- a/documents/matthew-create-frontend-runner.md
+++ b/documents/matthew-create-frontend-runner.md
@@ -1,0 +1,60 @@
+# Instructions for Matthew: Create the Frontend Self-Hosted Runner
+
+## Why you need to do this
+
+Because `secure-password-manager` is a personal-account repository under your GitHub account, the repository owner must create a repository-level self-hosted runner. After that, Eduardo can run the EC2-side commands on the frontend instance. See GitHub docs: https://docs.github.com/actions/hosting-your-own-runners/adding-self-hosted-runners
+
+## What to do in GitHub
+
+1. Open the repository: `mmfclarke/secure-password-manager`
+2. Go to **Settings**
+3. In the left sidebar, go to **Actions → Runners**
+4. Open the **Self-hosted runners** tab
+5. Click **New self-hosted runner**
+6. Select:
+   - **Operating system:** Linux
+   - **Architecture:** x64
+7. GitHub will generate the runner setup commands
+
+## What to send to Eduardo
+
+Send Eduardo the generated Linux/x64 runner setup commands from GitHub.
+
+He will run them on the frontend EC2 instance in:
+
+```bash
+/home/ubuntu/actions-runner
+```
+
+## After the runner is registered
+
+Once the runner appears in the repository runner list:
+
+1. Click the runner
+2. In the **Labels** section, add this custom label:
+
+```text
+frontend-ec2
+```
+
+This is important because the frontend workflow will target this label.
+
+## Workflow expectation
+
+The frontend workflow is expected to run on:
+
+```yaml
+runs-on: [self-hosted, linux, x64, frontend-ec2]
+```
+
+## Notes
+
+- This is for the **frontend EC2** only.
+- The EC2 instance already has Nginx and the GitHub runner software installed.
+- The old dummy test runner has already been removed from the EC2.
+- After runner creation is complete, Eduardo can finish the EC2-side registration and test the deployment.
+
+## GitHub references
+
+- Adding self-hosted runners: https://docs.github.com/actions/hosting-your-own-runners/adding-self-hosted-runners
+- Using labels with self-hosted runners: https://docs.github.com/actions/hosting-your-own-runners/using-labels-with-self-hosted-runners


### PR DESCRIPTION
## Summary

This PR updates the frontend workflow to use the self-hosted runner on the frontend EC2 instance instead of the previous GitHub-hosted SSH deployment approach.

## Changes

- switched frontend workflow to self-hosted runner
- build frontend with Vite in the workflow
- deploy built files to `/var/www/html`
- target custom runner label `frontend-ec2`

## Reason

This matches the frontend EC2 setup that was already tested and confirmed working:
- Nginx on EC2
- self-hosted runner on EC2
- frontend served from `/var/www/html`

## Remaining step after merge

Matthew still needs to create the repo-level self-hosted runner in the real repo and add the `frontend-ec2` label.