### PR TITLE
Verify backend autodeploy after EC2 fixes (closes #16)

### DIFF
--- a/backend/auto-deploy-smoke-test-second-attempt.txt
+++ b/backend/auto-deploy-smoke-test-second-attempt.txt
@@ -1,3 +1,3 @@
 Backend auto-deploy smoke test.
 Non-functional change to trigger backend GitHub Actions workflow.
-Attempt # 2
+Attempt # 3 - post systemd unit and .env relocation on team backend EC2.


### PR DESCRIPTION
## Summary

Non-functional change to `backend/auto-deploy-smoke-test-second-attempt.txt` to trigger the "Deploy Backend" GitHub Actions workflow and verify that the autodeploy pipeline now works end-to-end after the EC2-side fixes from issue #16.

## What was changed on the backend EC2 (out-of-band, prior to this PR)

All changes are on the live backend EC2 instance (ec2-54-201-88-115.us-west-2.compute.amazonaws.com), not in this repo:

1. Upgraded Node.js from 18.19.1 to 20.20.2 (required by mongoose@9.4.1)
2. Created `/etc/secure-password-manager-backend/.env` with `PORT=3001` and placeholder `JWT_SECRET`/`MONGO_URI`
3. Created `/etc/systemd/system/secure-password-manager-backend.service`
4. Enabled and started the service; confirmed `curl localhost:3001/` returns `API is running...`

## What this PR does

Only changes the smoke-test text file to trigger the deploy workflow. No code changes.

## Validation plan

After merge to main:
1. Workflow triggers on the `backend/**` path match
2. Self-hosted `467W26-PEREZE4-backend-runner` picks up the job
3. Workflow runs all 7 steps green (notably the `systemctl restart` step that was failing before)
4. Service restarts cleanly, `Server running on port 3001` visible in journalctl

## Follow-ups (tracked separately, not in this PR)

- Replace placeholder `JWT_SECRET` with a strong random value before backend is exposed to real users
- Wire up real DB and replace placeholder `MONGO_URI` (DocumentDB per project plan, or Atlas for dev)
- Mount `cors` middleware in `server.js` (currently imported but not `app.use()`'d)
- Update `backend/.env.example` to reflect `PORT=3001` instead of `5000`

Closes #16.