### PR TITLE
Add TLS CA file option to mongoose.connect (fixes #19)

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -9,7 +9,9 @@ const app = express();
 app.use(cors()); // 
 app.use(express.json()); 
 
-mongoose.connect(process.env.MONGO_URI)
+mongoose.connect(process.env.MONGO_URI, {
+  tlsCAFile: process.env.MONGO_TLS_CA_FILE,
+})
   .then(() => console.log("MongoDB connected"))
   .catch((err) => console.error("MongoDB connection error:", err));
 


### PR DESCRIPTION
Closes #19.

Enables the backend to connect to AWS DocumentDB by passing the `tlsCAFile`
option to `mongoose.connect`. The CA bundle path is read from the new
`MONGO_TLS_CA_FILE` env var (already set in the backend EC2 `.env`).

## Context
DocumentDB requires TLS for all client connections. Without `tlsCAFile`,
mongoose cannot verify the server certificate and the connection fails.

## Validation
Tested on the backend EC2 against the live DocumentDB cluster
(`pereze4-467w26-docdb-cluster`). After restart, backend logs show:
- `Server running on port 3001`
- `MongoDB connected`

## Scope
Single-line change in `backend/server.js`. No other files touched.
No behavior change for any existing functionality; this only adds the
TLS option needed for the DocumentDB deployment.