### PR TITLE
TOTP service framework with internal backend API

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -2,3 +2,7 @@ JWT_SECRET=your_jwt_secret_here
 PORT=5000
 
 MONGO_URI=your_mongodb_connection_string
+MONGO_TLS_CA_FILE=
+
+# Shared secret between backend and TOTP service — must match TOTP service .env
+TOTP_INTERNAL_SECRET=your_shared_internal_secret_here

--- a/backend/middleware/authMiddleware.js
+++ b/backend/middleware/authMiddleware.js
@@ -1,0 +1,27 @@
+const jwt = require("jsonwebtoken");
+const User = require("../models/User");
+
+const authMiddleware = async (req, res, next) => {
+  try {
+    const authHeader = req.headers.authorization;
+
+    if (!authHeader || !authHeader.startsWith("Bearer ")) {
+      return res.status(401).json({ message: "No token provided" });
+    }
+
+    const token = authHeader.split(" ")[1];
+    const decoded = jwt.verify(token, process.env.JWT_SECRET);
+    const user = await User.findById(decoded.userId);
+
+    if (!user) {
+      return res.status(401).json({ message: "User not found" });
+    }
+
+    req.user = user;
+    next();
+  } catch (err) {
+    return res.status(401).json({ message: "Invalid token" });
+  }
+};
+
+module.exports = authMiddleware;

--- a/backend/middleware/internalAuthMiddleware.js
+++ b/backend/middleware/internalAuthMiddleware.js
@@ -1,0 +1,11 @@
+const internalAuthMiddleware = (req, res, next) => {
+  const secret = req.headers["x-internal-secret"];
+
+  if (!secret || secret !== process.env.TOTP_INTERNAL_SECRET) {
+    return res.status(403).json({ message: "Forbidden" });
+  }
+
+  next();
+};
+
+module.exports = internalAuthMiddleware;

--- a/backend/routes/authRoutes.js
+++ b/backend/routes/authRoutes.js
@@ -49,9 +49,13 @@ router.post("/login", async (req, res) => {
       return res.status(400).json({ message: "Invalid credentials" });
     }
 
+    if (user.mfaEnabled) {
+      return res.json({ requireMFA: true, userId: user._id });
+    }
+
     const token = jwt.sign(
       { userId: user._id },
-       process.env.JWT_SECRET,
+      process.env.JWT_SECRET,
       { expiresIn: "1h" }
     );
 

--- a/backend/routes/internalRoutes.js
+++ b/backend/routes/internalRoutes.js
@@ -1,0 +1,59 @@
+const express = require("express");
+const jwt = require("jsonwebtoken");
+const User = require("../models/User");
+const internalAuthMiddleware = require("../middleware/internalAuthMiddleware");
+
+const router = express.Router();
+
+router.use(internalAuthMiddleware);
+
+router.get("/users/:userId/totp-secret", async (req, res) => {
+  try {
+    const user = await User.findById(req.params.userId).select("totpSecret");
+    if (!user) return res.status(404).json({ message: "User not found" });
+    if (!user.totpSecret) return res.status(400).json({ message: "TOTP not set up" });
+
+    res.json({ totpSecret: user.totpSecret });
+  } catch (err) {
+    res.status(500).json({ message: "Server error" });
+  }
+});
+
+router.put("/users/:userId/totp", async (req, res) => {
+  try {
+    const { totpSecret } = req.body;
+    const user = await User.findByIdAndUpdate(
+      req.params.userId,
+      { totpSecret },
+      { new: true }
+    );
+    if (!user) return res.status(404).json({ message: "User not found" });
+
+    res.json({ message: "TOTP secret saved" });
+  } catch (err) {
+    res.status(500).json({ message: "Server error" });
+  }
+});
+
+router.post("/users/:userId/complete-mfa", async (req, res) => {
+  try {
+    const user = await User.findByIdAndUpdate(
+      req.params.userId,
+      { mfaEnabled: true },
+      { new: true }
+    );
+    if (!user) return res.status(404).json({ message: "User not found" });
+
+    const token = jwt.sign(
+      { userId: user._id },
+      process.env.JWT_SECRET,
+      { expiresIn: "1h" }
+    );
+
+    res.json({ token });
+  } catch (err) {
+    res.status(500).json({ message: "Server error" });
+  }
+});
+
+module.exports = router;

--- a/backend/server.js
+++ b/backend/server.js
@@ -3,6 +3,7 @@ const express = require("express");
 const mongoose = require("mongoose");
 const cors = require("cors");
 const authRoutes = require("./routes/authRoutes");
+const internalRoutes = require("./routes/internalRoutes");
 
 const app = express();
 
@@ -16,6 +17,7 @@ mongoose.connect(process.env.MONGO_URI, {
   .catch((err) => console.error("MongoDB connection error:", err));
 
 app.use("/api/auth", authRoutes);
+app.use("/api/internal", internalRoutes);
 
 app.get("/", (req, res) => {
   res.send("API is running...");

--- a/documents/totp-architecture.md
+++ b/documents/totp-architecture.md
@@ -1,0 +1,143 @@
+# TOTP Service Architecture
+
+**Author:** Matthew Clarke
+**Branch:** `feat/matthew-totp_framework_suggestion`
+**Date:** 2026-04-27
+
+This document explains the structural decisions behind how the TOTP service is built and how it communicates with the backend. This branch is a reference implementation — not a merge target. Thania should use it as a guide when rewriting `feat/totp-service`.
+
+---
+
+## The Core Rule
+
+**Only one service touches the database: the backend.**
+
+The TOTP service runs on its own EC2 instance. It does not connect to DocumentDB. It does not import Mongoose. It does not define a User schema. All user data reads and writes go through the backend API over HTTP.
+
+---
+
+## Why
+
+Two services writing directly to the same database creates fragile schema duplication. If the User schema changes (which it already did once during PR #2), both services have to be updated in sync. When that doesn't happen, you get field name mismatches, silent data corruption, and broken auth — which is exactly what happened in `feat/totp-service`.
+
+By routing all DB operations through the backend:
+- The User schema is defined in exactly one place: `backend/models/User.js`
+- JWT issuance happens in exactly one place: the backend
+- The TOTP service becomes a thin, focused service that only knows about TOTP
+
+---
+
+## Responsibility Split
+
+| Concern | Owner |
+|---|---|
+| Database reads/writes | Backend |
+| bcrypt (password hashing) | Backend |
+| JWT issuance | Backend |
+| TOTP secret generation | TOTP service |
+| QR code generation | TOTP service |
+| TOTP token verification | TOTP service |
+
+---
+
+## Service Communication
+
+The TOTP service calls the backend via three internal endpoints, all protected with a shared secret header (`x-internal-secret`). These endpoints are not user-facing and should never be exposed publicly.
+
+```
+TOTP service ──── x-internal-secret header ────► Backend internal routes
+                                                    └── reads/writes User document
+                                                    └── issues JWT
+```
+
+### Internal endpoints (backend)
+
+| Method | Path | Called by TOTP service when |
+|---|---|---|
+| `GET` | `/api/internal/users/:userId/totp-secret` | Verifying a TOTP token — needs the stored secret |
+| `PUT` | `/api/internal/users/:userId/totp` | Setting up MFA — saves the generated secret |
+| `POST` | `/api/internal/users/:userId/complete-mfa` | Verification passed — flip `mfaEnabled: true` and get JWT |
+
+### Shared secret
+
+Both services have `TOTP_INTERNAL_SECRET` in their `.env`. The backend validates this on every request to `/api/internal/*` via `internalAuthMiddleware.js`. This prevents any outside traffic from hitting the internal endpoints even if they discover the route.
+
+---
+
+## MFA Login Flow (end to end)
+
+```
+1. User submits email + password to frontend
+2. Frontend → POST /api/auth/login (backend)
+3. Backend verifies bcrypt, checks mfaEnabled
+   └── if mfaEnabled: true → return { requireMFA: true, userId }
+   └── if mfaEnabled: false → return { token } (normal login)
+4. Frontend → POST /totp/verify (TOTP service) with { userId, token }
+5. TOTP service → GET /api/internal/users/:userId/totp-secret (backend)
+6. TOTP service runs speakeasy.totp.verify()
+   └── if invalid → return 400
+   └── if valid → continue
+7. TOTP service → POST /api/internal/users/:userId/complete-mfa (backend)
+8. Backend sets mfaEnabled: true, signs JWT, returns { token }
+9. TOTP service passes { token } back to frontend
+```
+
+## MFA Setup Flow (end to end)
+
+```
+1. Frontend → POST /totp/setup (TOTP service) with { userId }
+2. TOTP service generates speakeasy secret
+3. TOTP service → PUT /api/internal/users/:userId/totp (backend) with { totpSecret }
+4. Backend saves totpSecret to User document
+5. TOTP service generates QR code from secret
+6. TOTP service returns { qrCode } to frontend
+7. User scans QR code in authenticator app
+8. Frontend prompts user to verify with first TOTP code → goes through verify flow above
+```
+
+---
+
+## File Structure
+
+```
+backend/
+├── middleware/
+│   ├── authMiddleware.js          # JWT auth for user-facing protected routes
+│   └── internalAuthMiddleware.js  # Shared secret auth for TOTP service calls
+├── models/
+│   ├── User.js                    # Single source of truth for User schema
+│   └── Credentials.js
+├── routes/
+│   ├── authRoutes.js              # POST /api/auth/register, POST /api/auth/login
+│   └── internalRoutes.js         # Internal endpoints for TOTP service only
+└── server.js
+
+totp/
+├── controllers/
+│   └── totpController.js          # speakeasy logic + axios calls to backend
+├── routes/
+│   └── totpRoutes.js              # POST /totp/setup, POST /totp/verify
+└── server.js                      # Express only — no mongoose, no DB connection
+```
+
+---
+
+## Environment Variables
+
+**Backend `.env`:**
+```
+JWT_SECRET=
+PORT=5000
+MONGO_URI=
+MONGO_TLS_CA_FILE=
+TOTP_INTERNAL_SECRET=
+```
+
+**TOTP service `.env`:**
+```
+PORT=4000
+BACKEND_API_URL=
+TOTP_INTERNAL_SECRET=
+```
+
+`TOTP_INTERNAL_SECRET` must be the same value in both `.env` files. `JWT_SECRET` lives only in the backend — the TOTP service never signs tokens.

--- a/totp/.env.example
+++ b/totp/.env.example
@@ -1,0 +1,3 @@
+PORT=4000
+BACKEND_API_URL=http://localhost:3001
+TOTP_INTERNAL_SECRET=your_shared_internal_secret_here

--- a/totp/controllers/totpController.js
+++ b/totp/controllers/totpController.js
@@ -1,0 +1,66 @@
+const speakeasy = require("speakeasy");
+const qrcode = require("qrcode");
+const axios = require("axios");
+
+const backendApi = axios.create({
+  baseURL: process.env.BACKEND_API_URL,
+  headers: {
+    "x-internal-secret": process.env.TOTP_INTERNAL_SECRET,
+  },
+});
+
+exports.setupMFA = async (req, res) => {
+  try {
+    const { userId } = req.body;
+
+    const secret = speakeasy.generateSecret({ length: 20 });
+
+    await backendApi.put(`/api/internal/users/${userId}/totp`, {
+      totpSecret: secret.base32,
+    });
+
+    const otpauthUrl = speakeasy.otpauthURL({
+      secret: secret.base32,
+      label: "SecurePasswordManager",
+      issuer: "SecurePasswordManager",
+      encoding: "base32",
+    });
+
+    const qrCode = await qrcode.toDataURL(otpauthUrl);
+
+    res.json({ qrCode });
+  } catch (err) {
+    console.error("setupMFA error:", err.message);
+    res.status(500).json({ message: "Failed to set up MFA" });
+  }
+};
+
+exports.verifyMFA = async (req, res) => {
+  try {
+    const { userId, token } = req.body;
+
+    const { data: secretData } = await backendApi.get(
+      `/api/internal/users/${userId}/totp-secret`
+    );
+
+    const verified = speakeasy.totp.verify({
+      secret: secretData.totpSecret,
+      encoding: "base32",
+      token,
+      window: 1,
+    });
+
+    if (!verified) {
+      return res.status(400).json({ message: "Invalid MFA token" });
+    }
+
+    const { data: authData } = await backendApi.post(
+      `/api/internal/users/${userId}/complete-mfa`
+    );
+
+    res.json({ token: authData.token });
+  } catch (err) {
+    console.error("verifyMFA error:", err.message);
+    res.status(500).json({ message: "Failed to verify MFA" });
+  }
+};

--- a/totp/package.json
+++ b/totp/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "secure-password-manager-totp",
+  "version": "1.0.0",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js",
+    "dev": "nodemon server.js"
+  },
+  "dependencies": {
+    "axios": "^1.7.0",
+    "cors": "^2.8.6",
+    "dotenv": "^17.4.2",
+    "express": "^5.2.1",
+    "qrcode": "^1.5.4",
+    "speakeasy": "^2.0.0"
+  }
+}

--- a/totp/routes/totpRoutes.js
+++ b/totp/routes/totpRoutes.js
@@ -1,0 +1,8 @@
+const express = require("express");
+const router = express.Router();
+const { setupMFA, verifyMFA } = require("../controllers/totpController");
+
+router.post("/setup", setupMFA);
+router.post("/verify", verifyMFA);
+
+module.exports = router;

--- a/totp/server.js
+++ b/totp/server.js
@@ -1,0 +1,18 @@
+const express = require("express");
+const cors = require("cors");
+require("dotenv").config();
+
+const totpRoutes = require("./routes/totpRoutes");
+
+const app = express();
+
+app.use(cors());
+app.use(express.json());
+
+app.use("/totp", totpRoutes);
+
+const PORT = process.env.PORT || 4000;
+
+app.listen(PORT, () => {
+  console.log(`TOTP service running on port ${PORT}`);
+});


### PR DESCRIPTION
## Proposed TOTP Service Architecture
This branch establishes the structure for the TOTP service as a standalone Express app running on its own EC2 instance.

### What the TOTP service is responsible for:
- Generating TOTP secrets via speakeasy
- Generating QR codes for authenticator app enrollment
- Verifying TOTP tokens submitted by the user


### What it is NOT responsible for:
- Connecting to DocumentDB (no mongoose, no DB connection)
- Issuing JWTs (JWT_SECRET lives in the backend only)
- Any user data storage or retrieval
 
### How it talks to the backend:
The TOTP service calls three internal backend endpoints over HTTP using axios. Every request includes an x-internal-secret header, a shared secret set in both services' environment variables that the backend validates before allowing the request through. These endpoints are not user-facing.

PUT /api/internal/users/:userId/totp - saves the generated TOTP secret during setup
GET /api/internal/users/:userId/totp-secret - retrieves the secret during verification
POST /api/internal/users/:userId/complete-mfa - after successful token verification, the backend sets mfaEnabled: true and issues the JWT, which the TOTP service passes back to the frontend

JWT flow: The backend issues all JWTs. For a normal login (no MFA), the backend issues the JWT directly. For an MFA login, the TOTP service verifies the token and calls the backend to issue the JWT. The TOTP service never signs anything itself.

## Proposed Action Items
### Thania:
- Rewrite feat/totp-service using this branch as a reference
- Remove mongoose and the DB connection from the TOTP service entirely
- Remove totp/models/User.js and the inline schema from totpController.js
- Delete backend/controllers/authController.js
- Implement the three internal backend endpoints from backend/routes/internalRoutes.js
- Fix verifyMFA to complete enrollment via complete-mfa rather than issuing the JWT itself
- See documents/totp-architecture.md for the full flow diagrams

### Eduardo:
- TOTP EC2 instance env needs: PORT, BACKEND_API_URL, TOTP_INTERNAL_SECRET
- Backend EC2 instance env needs: TOTP_INTERNAL_SECRET added alongside existing vars
- TOTP_INTERNAL_SECRET must be the same value on both instances - generate one strong random string and set it in both
- EC2 setup is blocked until Thania's corrected branch is merged