### PR TITLE
feat: add unified AWS CloudFormation stack template for demo (#26)

### DIFF
--- a/AWS-CloudFormation/467W26-PEREZE4-cfn-stack.yaml
+++ b/AWS-CloudFormation/467W26-PEREZE4-cfn-stack.yaml
@@ -1,0 +1,271 @@
+AWSTemplateFormatVersion: '2010-09-09'
+
+Description: >
+  Self-contained unified stack for the Secure Password Manager capstone demo.
+  Creates a VPC, public subnet, IGW, route table, two security groups
+  (frontend-sg and app-sg), and three t3.micro Ubuntu 24.04 EC2 instances
+  (frontend, backend, TOTP) in us-west-2a. Frontend has an Elastic IP;
+  backend and TOTP get auto-assigned public IPs. Modeled after the team
+  live environment.
+
+Parameters:
+
+  SshSourceCidr:
+    Type: String
+    Description: >
+      CIDR block allowed to SSH (port 22) into all three instances. Use your
+      public IP with a /32 suffix, e.g. 203.0.113.42/32. Do NOT use 0.0.0.0/0
+      in anything other than throwaway demo runs.
+    AllowedPattern: '^([0-9]{1,3}\.){3}[0-9]{1,3}/[0-9]{1,2}$'
+    ConstraintDescription: Must be a valid CIDR block (e.g. 203.0.113.42/32).
+
+  KeyPairName:
+    Type: AWS::EC2::KeyPair::KeyName
+    Description: >
+      Name of an existing EC2 key pair in this account/region. Required for
+      SSH access to all three instances.
+
+Resources:
+
+  # Networking
+
+  Vpc:
+    Type: AWS::EC2::VPC
+    Properties:
+      CidrBlock: 10.0.0.0/20
+      EnableDnsSupport: true
+      EnableDnsHostnames: true
+      Tags:
+        - Key: Name
+          Value: 467W26-PEREZE4-cfn-vpc
+
+  InternetGateway:
+    Type: AWS::EC2::InternetGateway
+    Properties:
+      Tags:
+        - Key: Name
+          Value: 467W26-PEREZE4-cfn-igw
+
+  IgwAttachment:
+    Type: AWS::EC2::VPCGatewayAttachment
+    Properties:
+      VpcId: !Ref Vpc
+      InternetGatewayId: !Ref InternetGateway
+
+  PublicSubnet:
+    Type: AWS::EC2::Subnet
+    Properties:
+      VpcId: !Ref Vpc
+      CidrBlock: 10.0.0.0/24
+      AvailabilityZone: us-west-2a
+      MapPublicIpOnLaunch: true
+      Tags:
+        - Key: Name
+          Value: 467W26-PEREZE4-cfn-subnet
+
+  PublicRouteTable:
+    Type: AWS::EC2::RouteTable
+    Properties:
+      VpcId: !Ref Vpc
+      Tags:
+        - Key: Name
+          Value: 467W26-PEREZE4-cfn-rtb
+
+  DefaultPublicRoute:
+    Type: AWS::EC2::Route
+    DependsOn: IgwAttachment
+    Properties:
+      RouteTableId: !Ref PublicRouteTable
+      DestinationCidrBlock: 0.0.0.0/0
+      GatewayId: !Ref InternetGateway
+
+  PublicSubnetRouteTableAssoc:
+    Type: AWS::EC2::SubnetRouteTableAssociation
+    Properties:
+      RouteTableId: !Ref PublicRouteTable
+      SubnetId: !Ref PublicSubnet
+
+  # Security Groups
+
+  FrontendSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: Frontend security group
+      VpcId: !Ref Vpc
+      SecurityGroupIngress:
+        - IpProtocol: tcp
+          FromPort: 80
+          ToPort: 80
+          CidrIp: 0.0.0.0/0
+          Description: Public HTTP access
+        - IpProtocol: tcp
+          FromPort: 443
+          ToPort: 443
+          CidrIp: 0.0.0.0/0
+          Description: Public HTTPS access
+        - IpProtocol: tcp
+          FromPort: 22
+          ToPort: 22
+          CidrIp: !Ref SshSourceCidr
+          Description: SSH access from deployer
+      SecurityGroupEgress:
+        - IpProtocol: '-1'
+          CidrIp: 0.0.0.0/0
+          Description: Allow all outbound
+      Tags:
+        - Key: Name
+          Value: 467W26-PEREZE4-cfn-frontend-sg
+
+  AppSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: Backend and TOTP security group
+      VpcId: !Ref Vpc
+      SecurityGroupEgress:
+        - IpProtocol: '-1'
+          CidrIp: 0.0.0.0/0
+          Description: Allow all outbound
+      Tags:
+        - Key: Name
+          Value: 467W26-PEREZE4-cfn-app-sg
+
+  # Inbound rules for app-sg defined separately to allow self-referencing
+
+  AppSgIngressSsh:
+    Type: AWS::EC2::SecurityGroupIngress
+    Properties:
+      GroupId: !Ref AppSecurityGroup
+      IpProtocol: tcp
+      FromPort: 22
+      ToPort: 22
+      CidrIp: !Ref SshSourceCidr
+      Description: SSH access from deployer
+
+  AppSgIngressBackend:
+    Type: AWS::EC2::SecurityGroupIngress
+    Properties:
+      GroupId: !Ref AppSecurityGroup
+      IpProtocol: tcp
+      FromPort: 3001
+      ToPort: 3001
+      SourceSecurityGroupId: !Ref FrontendSecurityGroup
+      Description: Frontend SG to backend app port
+
+  AppSgIngressTotp:
+    Type: AWS::EC2::SecurityGroupIngress
+    Properties:
+      GroupId: !Ref AppSecurityGroup
+      IpProtocol: tcp
+      FromPort: 3002
+      ToPort: 3002
+      SourceSecurityGroupId: !Ref AppSecurityGroup
+      Description: App SG to TOTP service port
+
+  # EC2 Instances
+
+  FrontendInstance:
+    Type: AWS::EC2::Instance
+    Properties:
+      InstanceType: t3.micro
+      ImageId: ami-0d76b909de1a0595d
+      KeyName: !Ref KeyPairName
+      SubnetId: !Ref PublicSubnet
+      SecurityGroupIds:
+        - !Ref FrontendSecurityGroup
+      BlockDeviceMappings:
+        - DeviceName: /dev/sda1
+          Ebs:
+            VolumeSize: 8
+            VolumeType: gp3
+            Encrypted: false
+            DeleteOnTermination: true
+      Tags:
+        - Key: Name
+          Value: 467W26-PEREZE4-cfn-frontend-ec2
+
+  BackendInstance:
+    Type: AWS::EC2::Instance
+    Properties:
+      InstanceType: t3.micro
+      ImageId: ami-0d76b909de1a0595d
+      KeyName: !Ref KeyPairName
+      SubnetId: !Ref PublicSubnet
+      SecurityGroupIds:
+        - !Ref AppSecurityGroup
+      BlockDeviceMappings:
+        - DeviceName: /dev/sda1
+          Ebs:
+            VolumeSize: 8
+            VolumeType: gp3
+            Encrypted: false
+            DeleteOnTermination: true
+      Tags:
+        - Key: Name
+          Value: 467W26-PEREZE4-cfn-backend-ec2
+
+  TotpInstance:
+    Type: AWS::EC2::Instance
+    Properties:
+      InstanceType: t3.micro
+      ImageId: ami-0d76b909de1a0595d
+      KeyName: !Ref KeyPairName
+      SubnetId: !Ref PublicSubnet
+      SecurityGroupIds:
+        - !Ref AppSecurityGroup
+      BlockDeviceMappings:
+        - DeviceName: /dev/sda1
+          Ebs:
+            VolumeSize: 8
+            VolumeType: gp3
+            Encrypted: false
+            DeleteOnTermination: true
+      Tags:
+        - Key: Name
+          Value: 467W26-PEREZE4-cfn-totp-ec2
+
+  # Elastic IP (frontend only, matches team live)
+
+  FrontendEip:
+    Type: AWS::EC2::EIP
+    DependsOn: IgwAttachment
+    Properties:
+      Domain: vpc
+      Tags:
+        - Key: Name
+          Value: 467W26-PEREZE4-cfn-frontend-eip
+
+  FrontendEipAssociation:
+    Type: AWS::EC2::EIPAssociation
+    Properties:
+      AllocationId: !GetAtt FrontendEip.AllocationId
+      InstanceId: !Ref FrontendInstance
+
+Outputs:
+
+  FrontendInstanceId:
+    Description: Frontend EC2 instance ID
+    Value: !Ref FrontendInstance
+
+  FrontendPublicIp:
+    Description: Frontend Elastic IP (static)
+    Value: !Ref FrontendEip
+
+  FrontendSshCommand:
+    Description: SSH command for frontend
+    Value: !Sub 'ssh -i ${KeyPairName}.pem ubuntu@${FrontendEip}'
+
+  BackendInstanceId:
+    Description: Backend EC2 instance ID
+    Value: !Ref BackendInstance
+
+  BackendPublicIp:
+    Description: Backend auto-assigned public IP (changes on stop/start)
+    Value: !GetAtt BackendInstance.PublicIp
+
+  TotpInstanceId:
+    Description: TOTP EC2 instance ID
+    Value: !Ref TotpInstance
+
+  TotpPublicIp:
+    Description: TOTP auto-assigned public IP (changes on stop/start)
+    Value: !GetAtt TotpInstance.PublicIp


### PR DESCRIPTION
Closes #26


## Video Explanation

[Demo video (Canvas)](https://canvas.oregonstate.edu/groups/723237/files?preview=118253737)

## Summary

Adds `AWS-CloudFormation/467W26-PEREZE4-cfn-stack.yaml`, a self-contained
CloudFormation template that mirrors the team live environment. One deploy
command stands up the full app infrastructure for demo purposes; one
delete-stack command tears it back down.

## What the template provisions

- 1 VPC (`10.0.0.0/20`) + 1 public subnet (`10.0.0.0/24`) in us-west-2a
- 1 IGW + route table + default route
- 2 security groups: `frontend-sg` (80/443 open, 22 from parameter) and
  `app-sg` (22 from parameter, 3001 from frontend-sg, 3002 self-referenced)
- 3 EC2 instances (frontend, backend, TOTP), all t3.micro Ubuntu 24.04
- 1 Elastic IP attached to frontend (matches team live; backend and TOTP
  get auto-assigned public IPs)

## Parameters at deploy time

- `SshSourceCidr` (validated CIDR, no default)
- `KeyPairName` (must already exist in the account)

## Out of scope

- HTTPS / ACM
- IAM roles
- GitHub Actions runner registration
- Application bootstrap (nginx, React build, Node service, etc.)
- DocumentDB provisioning

## Verification

- `validate-template` passed
- Full deploy + teardown cycle tested end to end in the account
- Confirmed VPC/subnet/IGW/SGs/3 EC2s/1 EIP came up correctly with
  resources tagged `467W26-PEREZE4-cfn-*`
- Confirmed clean teardown (zero leftover cfn-tagged resources)

