### PR TITLE
Add clipboard fallback for plain HTTP (closes #36)

### DIFF
--- a/frontend/src/components/PasswordGenerator.jsx
+++ b/frontend/src/components/PasswordGenerator.jsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback } from "react";
 import { X, Copy, RefreshCw } from "lucide-react";
 import styles from "../styles/PasswordGenerator.module.css";
+import { copyToClipboard } from "../utils/clipboard";
 
 const CHARSETS = {
   uppercase: "ABCDEFGHIJKLMNOPQRSTUVWXYZ",
@@ -54,7 +55,7 @@ export default function PasswordGenerator({ onClose, onSaveToVault }) {
   }, [generate]);
 
   const handleCopy = () => {
-    navigator.clipboard.writeText(password);
+    copyToClipboard(password);
     setCopied(true);
     setTimeout(() => setCopied(false), 2000);
   };

--- a/frontend/src/pages/Vault.jsx
+++ b/frontend/src/pages/Vault.jsx
@@ -5,6 +5,7 @@ import styles from "../styles/Vault.module.css";
 import { Key, Lock, Plus, Pencil, Trash2, Copy, Check, Eye, EyeOff, ExternalLink } from "lucide-react";
 import PasswordGenerator from "../components/PasswordGenerator";
 import { encrypt, decrypt } from "../utils/crypto";
+import { copyToClipboard } from "../utils/clipboard";
 
 const FILTERS = ["All", "Personal", "Work", "Finance", "Social", "Other"];
 
@@ -91,7 +92,7 @@ export default function Vault({ masterPassword, setMasterPassword }) {
   };
 
   const handleCopy = (text, id, field) => {
-    navigator.clipboard.writeText(text);
+    copyToClipboard(text);
     setCopiedField({ id, field });
     setTimeout(() => setCopiedField(null), 2000);
   };

--- a/frontend/src/utils/clipboard.js
+++ b/frontend/src/utils/clipboard.js
@@ -1,0 +1,43 @@
+/**
+ * Copies text to the clipboard.
+ *
+ * Tries the modern Clipboard API first (works in HTTPS, localhost, and file://).
+ * Falls back to a hidden-textarea + document.execCommand("copy") for non-secure
+ * contexts (plain HTTP), which is currently the case on team prod and REPLICATE
+ * until HTTPS lands.
+ *
+ * @param {string} text - Text to copy to the clipboard.
+ * @returns {Promise<boolean>} - true if the copy succeeded, false otherwise.
+ */
+export async function copyToClipboard(text) {
+  if (navigator.clipboard && window.isSecureContext) {
+    try {
+      await navigator.clipboard.writeText(text);
+      return true;
+    } catch {
+      // Fall through to legacy fallback if the modern API throws
+    }
+  }
+
+  const textarea = document.createElement("textarea");
+  textarea.value = text;
+  textarea.setAttribute("readonly", "");
+  textarea.style.position = "fixed";
+  textarea.style.top = "0";
+  textarea.style.left = "-9999px";
+  textarea.style.opacity = "0";
+  document.body.appendChild(textarea);
+
+  textarea.focus();
+  textarea.select();
+
+  let success = false;
+  try {
+    success = document.execCommand("copy");
+  } catch {
+    success = false;
+  }
+
+  document.body.removeChild(textarea);
+  return success;
+}


### PR DESCRIPTION
Closes #36.

## Changes

Adds `frontend/src/utils/clipboard.js`, a small utility that:
1. Tries `navigator.clipboard.writeText()` if `window.isSecureContext` is true.
2. Falls back to a hidden-textarea + `document.execCommand("copy")` for non-secure contexts.

Updates the two call sites in `Vault.jsx` and `PasswordGenerator.jsx` to use the utility instead of calling `navigator.clipboard.writeText()` directly. UX is unchanged (optimistic "Copied!" indicator, no awaiting).

## Verification

Tested on REPLICATE (HTTP) on commit `862ea9f`:
- Vault credential username copy works (paste verified)
- Vault credential password copy works (paste verified)
- Password generator output copy works (paste verified)

Confirmed deployed bundle on REPLICATE frontend EC2 contains both `execCommand` and `isSecureContext` strings (`/var/www/html/assets/index-_zZSfXNt.js`).

## Note

Independent of and complementary to the upcoming HTTPS work. Once HTTPS lands, the modern API path takes over automatically. The fallback stays as a safety net for any future non-secure contexts.