### PR TITLE
Add API integration tests with GitHub Actions CI (closes #38)

### DIFF
--- a/.github/workflows/api-tests.yml
+++ b/.github/workflows/api-tests.yml
@@ -1,0 +1,90 @@
+name: API Tests
+
+on: [push, pull_request]
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    services:
+      mongodb:
+        image: mongo:7
+        ports:
+          - 27017:27017
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install backend dependencies
+        working-directory: backend
+        run: npm ci
+
+      - name: Install TOTP service dependencies
+        working-directory: totp
+        run: npm ci
+
+      - name: Start backend in background
+        working-directory: backend
+        env:
+          MONGO_URI: mongodb://localhost:27017/securepm-test
+          JWT_SECRET: test-jwt-secret-for-ci-only
+          FRONTEND_ORIGIN: http://localhost:5173
+          TOTP_INTERNAL_SECRET: test-internal-secret-for-ci-only
+          PORT: 3001
+        run: |
+          npm start > /tmp/backend.log 2>&1 &
+          for i in {1..30}; do
+            if curl -sf http://localhost:3001/ > /dev/null; then
+              echo "Backend is up"
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "Backend failed to start within 30 seconds"
+          exit 1
+
+      - name: Start TOTP service in background
+        working-directory: totp
+        env:
+          PORT: 4000
+          BACKEND_API_URL: http://localhost:3001
+          TOTP_INTERNAL_SECRET: test-internal-secret-for-ci-only
+        run: |
+          npm start > /tmp/totp.log 2>&1 &
+          for i in {1..30}; do
+            if nc -z localhost 4000; then
+              echo "TOTP service is up"
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "TOTP service failed to start within 30 seconds"
+          exit 1
+
+      - name: Install test dependencies
+        working-directory: tests
+        run: npm install
+
+      - name: Run API tests
+        working-directory: tests
+        env:
+          API_BASE_URL: http://localhost:3001
+          TOTP_BASE_URL: http://localhost:4000
+          TOTP_INTERNAL_SECRET: test-internal-secret-for-ci-only
+        run: npm test
+
+      - name: Show backend logs on failure
+        if: failure()
+        run: cat /tmp/backend.log || true
+
+      - name: Show TOTP logs on failure
+        if: failure()
+        run: cat /tmp/totp.log || true

--- a/tests/auth.api.test.js
+++ b/tests/auth.api.test.js
@@ -1,0 +1,27 @@
+const request = require("supertest");
+const { API_URL, uniqueEmail } = require("./helpers");
+
+describe("Auth API happy path", () => {
+  const email = uniqueEmail("auth");
+  const password = "TestPass123!";
+
+  test("POST /api/auth/register creates a new user", async () => {
+    const res = await request(API_URL)
+      .post("/api/auth/register")
+      .send({ email, password });
+
+    expect(res.status).toBe(201);
+    expect(res.body.message).toBe("User created");
+    expect(res.body).toHaveProperty("userId");
+  });
+
+  test("POST /api/auth/login with valid credentials prompts MFA setup", async () => {
+    const res = await request(API_URL)
+      .post("/api/auth/login")
+      .send({ email, password });
+
+    expect(res.status).toBe(200);
+    expect(res.body.requireMFASetup).toBe(true);
+    expect(res.body).toHaveProperty("userId");
+  });
+});

--- a/tests/credentials.api.test.js
+++ b/tests/credentials.api.test.js
@@ -1,0 +1,77 @@
+const request = require("supertest");
+const { API_URL, uniqueEmail, registerUser, getJwt } = require("./helpers");
+
+describe("Credentials API happy path", () => {
+  let jwtToken;
+  let credentialId;
+
+  beforeAll(async () => {
+    const email = uniqueEmail("creds");
+    const password = "TestPass123!";
+    const userId = await registerUser(email, password);
+    jwtToken = await getJwt(userId);
+  });
+
+  test("POST /api/credentials creates a credential", async () => {
+    const res = await request(API_URL)
+      .post("/api/credentials")
+      .set("Authorization", `Bearer ${jwtToken}`)
+      .send({
+        title: "Test Site",
+        website: "https://example.com",
+        category: "personal",
+        encryptedData: {
+          ciphertext: "fakeCiphertextBase64==",
+          iv: "fakeIvBase64==",
+          salt: "fakeSaltBase64==",
+        },
+      });
+
+    expect(res.status).toBe(201);
+    expect(res.body).toHaveProperty("_id");
+    expect(res.body.title).toBe("Test Site");
+    expect(res.body.category).toBe("personal");
+
+    credentialId = res.body._id;
+  });
+
+  test("GET /api/credentials returns a list including the new credential", async () => {
+    const res = await request(API_URL)
+      .get("/api/credentials")
+      .set("Authorization", `Bearer ${jwtToken}`);
+
+    expect(res.status).toBe(200);
+    expect(Array.isArray(res.body)).toBe(true);
+    expect(res.body.some((c) => c._id === credentialId)).toBe(true);
+  });
+
+  test("GET /api/credentials/:id returns the credential", async () => {
+    const res = await request(API_URL)
+      .get(`/api/credentials/${credentialId}`)
+      .set("Authorization", `Bearer ${jwtToken}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body._id).toBe(credentialId);
+    expect(res.body.title).toBe("Test Site");
+  });
+
+  test("PUT /api/credentials/:id updates the credential", async () => {
+    const res = await request(API_URL)
+      .put(`/api/credentials/${credentialId}`)
+      .set("Authorization", `Bearer ${jwtToken}`)
+      .send({ title: "Updated Test Site" });
+
+    expect(res.status).toBe(200);
+    expect(res.body._id).toBe(credentialId);
+    expect(res.body.title).toBe("Updated Test Site");
+  });
+
+  test("DELETE /api/credentials/:id removes the credential", async () => {
+    const res = await request(API_URL)
+      .delete(`/api/credentials/${credentialId}`)
+      .set("Authorization", `Bearer ${jwtToken}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.message).toBe("Deleted successfully");
+  });
+});

--- a/tests/helpers.js
+++ b/tests/helpers.js
@@ -1,0 +1,74 @@
+const request = require("supertest");
+const speakeasy = require("speakeasy");
+
+const API_URL = process.env.API_BASE_URL || "http://localhost:3001";
+const TOTP_URL = process.env.TOTP_BASE_URL || "http://localhost:4000";
+const INTERNAL_SECRET = process.env.TOTP_INTERNAL_SECRET;
+
+if (!INTERNAL_SECRET) {
+  throw new Error(
+    "TOTP_INTERNAL_SECRET env var is required to run these tests"
+  );
+}
+
+function uniqueEmail(prefix) {
+  const random = Math.random().toString(36).slice(2, 8);
+  return `${prefix}-${Date.now()}-${random}@example.com`;
+}
+
+async function registerUser(email, password) {
+  const res = await request(API_URL)
+    .post("/api/auth/register")
+    .send({ email, password });
+
+  if (res.status !== 201) {
+    throw new Error(
+      `registerUser failed: ${res.status} ${JSON.stringify(res.body)}`
+    );
+  }
+  return res.body.userId;
+}
+
+async function getJwt(userId) {
+  const res = await request(API_URL)
+    .post(`/api/internal/users/${userId}/complete-mfa`)
+    .set("x-internal-secret", INTERNAL_SECRET);
+
+  if (res.status !== 200) {
+    throw new Error(
+      `getJwt failed: ${res.status} ${JSON.stringify(res.body)}`
+    );
+  }
+  return res.body.token;
+}
+
+async function getTotpSecret(userId) {
+  const res = await request(API_URL)
+    .get(`/api/internal/users/${userId}/totp-secret`)
+    .set("x-internal-secret", INTERNAL_SECRET);
+
+  if (res.status !== 200) {
+    throw new Error(
+      `getTotpSecret failed: ${res.status} ${JSON.stringify(res.body)}`
+    );
+  }
+  return res.body.totpSecret;
+}
+
+function generateTotpCode(secret) {
+  return speakeasy.totp({
+    secret,
+    encoding: "base32",
+  });
+}
+
+module.exports = {
+  API_URL,
+  TOTP_URL,
+  INTERNAL_SECRET,
+  uniqueEmail,
+  registerUser,
+  getJwt,
+  getTotpSecret,
+  generateTotpCode,
+};

--- a/tests/internal.api.test.js
+++ b/tests/internal.api.test.js
@@ -1,0 +1,48 @@
+const request = require("supertest");
+const {
+  API_URL,
+  INTERNAL_SECRET,
+  uniqueEmail,
+  registerUser,
+} = require("./helpers");
+
+const TEST_TOTP_SECRET = "JBSWY3DPEHPK3PXPJBSWY3DPEHPK3PXP";
+
+describe("Internal API happy path", () => {
+  let userId;
+
+  beforeAll(async () => {
+    const email = uniqueEmail("internal");
+    const password = "TestPass123!";
+    userId = await registerUser(email, password);
+  });
+
+  test("PUT /api/internal/users/:userId/totp saves the TOTP secret", async () => {
+    const res = await request(API_URL)
+      .put(`/api/internal/users/${userId}/totp`)
+      .set("x-internal-secret", INTERNAL_SECRET)
+      .send({ totpSecret: TEST_TOTP_SECRET });
+
+    expect(res.status).toBe(200);
+    expect(res.body.message).toBe("TOTP secret saved");
+  });
+
+  test("GET /api/internal/users/:userId/totp-secret returns the saved secret", async () => {
+    const res = await request(API_URL)
+      .get(`/api/internal/users/${userId}/totp-secret`)
+      .set("x-internal-secret", INTERNAL_SECRET);
+
+    expect(res.status).toBe(200);
+    expect(res.body.totpSecret).toBe(TEST_TOTP_SECRET);
+  });
+
+  test("POST /api/internal/users/:userId/complete-mfa returns a JWT", async () => {
+    const res = await request(API_URL)
+      .post(`/api/internal/users/${userId}/complete-mfa`)
+      .set("x-internal-secret", INTERNAL_SECRET);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty("token");
+    expect(typeof res.body.token).toBe("string");
+  });
+});

--- a/tests/package.json
+++ b/tests/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "secure-password-manager-tests",
+  "version": "1.0.0",
+  "private": true,
+  "description": "API happy path tests for the Secure Password Manager",
+  "scripts": {
+    "test": "jest --runInBand"
+  },
+  "devDependencies": {
+    "jest": "^29.7.0",
+    "speakeasy": "^2.0.0",
+    "supertest": "^7.0.0"
+  }
+}

--- a/tests/totp.api.test.js
+++ b/tests/totp.api.test.js
@@ -1,0 +1,41 @@
+const request = require("supertest");
+const {
+  TOTP_URL,
+  uniqueEmail,
+  registerUser,
+  getTotpSecret,
+  generateTotpCode,
+} = require("./helpers");
+
+describe("TOTP service API happy path", () => {
+  let userId;
+
+  beforeAll(async () => {
+    const email = uniqueEmail("totp");
+    const password = "TestPass123!";
+    userId = await registerUser(email, password);
+  });
+
+  test("POST /totp/setup returns a QR code data URL", async () => {
+    const res = await request(TOTP_URL)
+      .post("/totp/setup")
+      .send({ userId });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty("qrCode");
+    expect(res.body.qrCode).toMatch(/^data:image\/png;base64,/);
+  });
+
+  test("POST /totp/verify with a valid generated code returns a JWT", async () => {
+    const secret = await getTotpSecret(userId);
+    const code = generateTotpCode(secret);
+
+    const res = await request(TOTP_URL)
+      .post("/totp/verify")
+      .send({ userId, token: code });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty("token");
+    expect(typeof res.body.token).toBe("string");
+  });
+});


### PR DESCRIPTION
Adds API integration tests and a GitHub Actions workflow to run them on every push and pull request.

Files added:
- `tests/package.json`, jest, supertest, speakeasy
- `tests/helpers.js`, shared setup (registerUser, getJwt, getTotpSecret, generateTotpCode)
- `tests/auth.api.test.js`, 2 tests
- `tests/credentials.api.test.js`, 5 tests
- `tests/internal.api.test.js`, 3 tests
- `tests/totp.api.test.js`, 2 tests
- `.github/workflows/api-tests.yml`, the workflow

Total: 12 tests across 4 files.

Scope: happy paths only. Edge cases (wrong password, lockout, validation, 401) are intentionally out of scope for this PR.

How verified: tested in my REPLICATE fork. All 12 tests passed in 32s end to end. Workflow run: https://github.com/mmfclarke/secure-password-manager/actions/runs/25590849556

Does not affect existing deploys. Path filters on `backend.yml`, `frontend.yml`, and `totp.yml` correctly exclude `tests/**` and `api-tests.yml`, so merging this won't redeploy any service.

Closes #38