### PR TITLE
fix: correct CryptoJS UTF-8 encoder name in vault decrypt

### DIFF
--- a/frontend/src/pages/Vault.jsx
+++ b/frontend/src/pages/Vault.jsx
@@ -39,8 +39,6 @@ export default function Vault({ masterPassword, setMasterPassword }) {
   const navigate = useNavigate();
 
   useEffect(() => {
-    const fp = (s) => `len=${s?.length ?? 0} cp=${s ? [...s].map(c => c.codePointAt(0).toString(16)).join(" ") : "-"}`;
-    console.log("[vault-debug] effect run, mp:", fp(masterPassword));
     const token = localStorage.getItem("token");
     if (!token) {
       navigate("/login");
@@ -62,7 +60,6 @@ export default function Vault({ masterPassword, setMasterPassword }) {
 
         let decrypted;
         try {
-          console.log("[vault-debug] about to decrypt, mp:", fp(masterPassword), "creds:", data.length);
           decrypted = data.map((cred) => {
             const { username, password } = JSON.parse(
               decrypt(cred.encryptedData.ciphertext, cred.encryptedData.iv, cred.encryptedData.salt, masterPassword)
@@ -70,7 +67,6 @@ export default function Vault({ masterPassword, setMasterPassword }) {
             return { ...cred, username, password };
           });
         } catch {
-          console.log("[vault-debug] decrypt failed with mp:", fp(masterPassword));
           setMasterPassword("");
           setUnlockError("Incorrect master password. Try again.");
           return;
@@ -111,8 +107,6 @@ export default function Vault({ masterPassword, setMasterPassword }) {
       setUnlockError("Enter your master password");
       return;
     }
-    const fp = (s) => `len=${s?.length ?? 0} cp=${s ? [...s].map(c => c.codePointAt(0).toString(16)).join(" ") : "-"}`;
-    console.log("[vault-debug] handleUnlock fired, unlockInput:", fp(unlockInput));
     setUnlockError("");
     setMasterPassword(unlockInput);
     setUnlockInput("");

--- a/frontend/src/utils/crypto.js
+++ b/frontend/src/utils/crypto.js
@@ -35,5 +35,5 @@ export function decrypt(ciphertext, iv, salt, masterPassword) {
   });
 
   const decrypted = CryptoJS.AES.decrypt(cipherParams, key, { iv: ivWords });
-  return decrypted.toString(CryptoJS.enc.UTF8);
+  return decrypted.toString(CryptoJS.enc.Utf8);
 }


### PR DESCRIPTION
## Summary
- One-character fix in `crypto.js`: `CryptoJS.enc.UTF8` → `CryptoJS.enc.Utf8`. The uppercase form is `undefined`, so `WordArray.toString(undefined)` was silently defaulting to Hex encoding. `decrypt()` returned a hex string of the plaintext bytes, `JSON.parse` threw, and Vault treated every correct master password as wrong.
- Removed the `[vault-debug]` console logs from `Vault.jsx` added in #45.

## Why this wasn't caught earlier
The unlock path was never exercised end-to-end with real decryption. Credential creation (`handleAdd`) pushes the plaintext form values directly into local state, so the UI worked without `decrypt()` ever being called. The bug only surfaces on page reload or fresh-login fetches, which is the flow that just got tested.

## Test plan
- [x] Fresh login + MFA → Vault loads existing credentials without the unlock overlay
- [x] Reload Vault → unlock overlay accepts the master password and decrypts existing credentials
- [x] Add a credential, reload, unlock — new credential decrypts correctly